### PR TITLE
fix(@yourssu/crypto): invalid base64 encoding when using sha256

### DIFF
--- a/.changeset/perfect-jars-agree.md
+++ b/.changeset/perfect-jars-agree.md
@@ -1,0 +1,5 @@
+---
+'@yourssu/crypto': minor
+---
+
+setting crypto package & create sha256, base64Encode, hexToUtf8

--- a/packages/crypto/src/base64Encode.test.ts
+++ b/packages/crypto/src/base64Encode.test.ts
@@ -2,6 +2,7 @@ import CryptoJS from 'crypto-js';
 import { describe, it, expect } from 'vitest';
 
 import { base64Encode } from './base64Encode';
+import { sha256 } from './sha256';
 
 describe('base64Encode', () => {
   it('should encode a string to base64', () => {
@@ -20,6 +21,20 @@ describe('base64Encode', () => {
         CryptoJS.enc.Utf8.parse(
           'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
         )
+      ).toString()
+    );
+  });
+
+  it('should encode an empty sha256 hash value to base64', () => {
+    expect(base64Encode(sha256(''))).toBe(
+      CryptoJS.enc.Base64.stringify(CryptoJS.SHA256('')).toString()
+    );
+  });
+
+  it('should encode a sha256 hash value to base64', () => {
+    expect(base64Encode('9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08')).toBe(
+      CryptoJS.enc.Base64.stringify(
+        CryptoJS.SHA256('9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08')
       ).toString()
     );
   });

--- a/packages/crypto/src/base64Encode.test.ts
+++ b/packages/crypto/src/base64Encode.test.ts
@@ -28,13 +28,13 @@ describe('base64Encode', () => {
 
   it('should encode an empty sha256 hash value to base64', () => {
     expect(base64Encode(hexToUtf8(sha256('')))).toBe(
-      CryptoJS.enc.Base64.stringify(CryptoJS.SHA256('')).toString()
+      CryptoJS.SHA256('').toString(CryptoJS.enc.Base64)
     );
   });
 
   it('should encode a sha256 hash value to base64', () => {
     expect(base64Encode(hexToUtf8(sha256('test')))).toBe(
-      CryptoJS.enc.Base64.stringify(CryptoJS.SHA256('test')).toString()
+      CryptoJS.SHA256('test').toString(CryptoJS.enc.Base64)
     );
   });
 });

--- a/packages/crypto/src/base64Encode.test.ts
+++ b/packages/crypto/src/base64Encode.test.ts
@@ -2,6 +2,7 @@ import CryptoJS from 'crypto-js';
 import { describe, it, expect } from 'vitest';
 
 import { base64Encode } from './base64Encode';
+import { hexToUtf8 } from './hexToUtf8.ts';
 import { sha256 } from './sha256';
 
 describe('base64Encode', () => {
@@ -26,16 +27,14 @@ describe('base64Encode', () => {
   });
 
   it('should encode an empty sha256 hash value to base64', () => {
-    expect(base64Encode(sha256(''))).toBe(
+    expect(base64Encode(hexToUtf8(sha256('')))).toBe(
       CryptoJS.enc.Base64.stringify(CryptoJS.SHA256('')).toString()
     );
   });
 
   it('should encode a sha256 hash value to base64', () => {
-    expect(base64Encode('9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08')).toBe(
-      CryptoJS.enc.Base64.stringify(
-        CryptoJS.SHA256('9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08')
-      ).toString()
+    expect(base64Encode(hexToUtf8(sha256('test')))).toBe(
+      CryptoJS.enc.Base64.stringify(CryptoJS.SHA256('test')).toString()
     );
   });
 });

--- a/packages/crypto/src/base64Encode.ts
+++ b/packages/crypto/src/base64Encode.ts
@@ -23,5 +23,6 @@ export function base64Encode(data: string): string {
   if (ret.length % 4 !== 0) {
     ret += '='.repeat(4 - (ret.length % 4));
   }
+
   return ret;
 }

--- a/packages/crypto/src/hexToUtf8.en.md
+++ b/packages/crypto/src/hexToUtf8.en.md
@@ -1,0 +1,34 @@
+# hexToUtf8
+
+The `hexToUtf8` function converts a hexadecimal string to a UTF-8 string.
+
+## Features
+
+- Converts the given hexadecimal string data to a UTF-8 string.
+- Returns the conversion result as a UTF-8 string.
+
+## API
+
+```ts
+hexToUtf8(hex
+:
+string
+):
+string;
+```
+
+### Parameters
+
+- `hex` (string): The hexadecimal string data to be converted.
+
+### Return value
+
+- `utf8` (string): The UTF-8 string obtained from converting the input hexadecimal string.
+
+## Examples
+
+```ts
+const hexString = '74657374';
+const utf8String = hexToUtf8(hexString);
+console.log('UTF-8 String:', utf8String); 
+```

--- a/packages/crypto/src/hexToUtf8.en.md
+++ b/packages/crypto/src/hexToUtf8.en.md
@@ -10,11 +10,7 @@ The `hexToUtf8` function converts a hexadecimal string to a UTF-8 string.
 ## API
 
 ```ts
-hexToUtf8(hex
-:
-string
-):
-string;
+hexToUtf8(hex: string): string;
 ```
 
 ### Parameters
@@ -30,5 +26,6 @@ string;
 ```ts
 const hexString = '74657374';
 const utf8String = hexToUtf8(hexString);
-console.log('UTF-8 String:', utf8String); 
+
+console.log('UTF-8 String:', utf8String);
 ```

--- a/packages/crypto/src/hexToUtf8.ko.md
+++ b/packages/crypto/src/hexToUtf8.ko.md
@@ -10,11 +10,7 @@
 ## API
 
 ```ts
-hexToUtf8(hex
-:
-string
-):
-string;
+hexToUtf8(hex: string): string;
 ```
 
 ### Parameters
@@ -30,5 +26,6 @@ string;
 ```ts
 const hexString = '74657374';
 const utf8String = hexToUtf8(hexString);
-console.log('UTF-8 String:', utf8String); 
+
+console.log('UTF-8 String:', utf8String);
 ```

--- a/packages/crypto/src/hexToUtf8.ko.md
+++ b/packages/crypto/src/hexToUtf8.ko.md
@@ -1,0 +1,34 @@
+# hexToUtf8
+
+`hexToUtf8` 함수는 16진수 문자열을 UTF-8 문자열로 변환합니다.
+
+## Features
+
+- 주어진 16 문자열 데이터를 UTF-8 문자열로 변환합니다.
+- 변환 결과를 UTF-8 문자열로 반환합니다.
+
+## API
+
+```ts
+hexToUtf8(hex
+:
+string
+):
+string;
+```
+
+### Parameters
+
+- `hex` (string): 암호화할 문자열 데이터입니다.
+
+### Return value
+
+- `utf8` (string): 입력된 16진수 문자열을 변환한 UTF-8 문자열입니다.
+
+## Examples
+
+```ts
+const hexString = '74657374';
+const utf8String = hexToUtf8(hexString);
+console.log('UTF-8 String:', utf8String); 
+```

--- a/packages/crypto/src/hexToUtf8.test.ts
+++ b/packages/crypto/src/hexToUtf8.test.ts
@@ -1,0 +1,8 @@
+import CryptoJS from 'crypto-js';
+import { expect, it } from 'vitest';
+
+import { hexToUtf8 } from './hexToUtf8.ts';
+
+it('should convert hex to utf8 correctly', () => {
+  expect(hexToUtf8(CryptoJS.enc.Utf8.parse('test').toString(CryptoJS.enc.Hex))).toBe('test');
+});

--- a/packages/crypto/src/hexToUtf8.ts
+++ b/packages/crypto/src/hexToUtf8.ts
@@ -1,0 +1,8 @@
+export function hexToUtf8(hex: string) {
+  let utf8 = '';
+  for (let i = 0; i < hex.length; i += 2) {
+    const byte = parseInt(hex.slice(i, i + 2), 16);
+    utf8 += String.fromCharCode(byte);
+  }
+  return utf8;
+}

--- a/packages/crypto/src/hexToUtf8.ts
+++ b/packages/crypto/src/hexToUtf8.ts
@@ -1,8 +1,10 @@
 export function hexToUtf8(hex: string) {
   let utf8 = '';
+
   for (let i = 0; i < hex.length; i += 2) {
     const byte = parseInt(hex.slice(i, i + 2), 16);
     utf8 += String.fromCharCode(byte);
   }
+
   return utf8;
 }

--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -1,2 +1,3 @@
 export { sha256 } from './sha256';
 export { base64Encode } from './base64Encode';
+export { hexToUtf8 } from './hexToUtf8';


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- resolved #32

### 작업 내용
- ```hexToUtf8``` 함수를 작성했습니다.
- ```md``` 파일과 ```test.ts```도 작성했습니다.
- ```hexToUtf8```를 통하여 기존 문제를 해결할 수 있습니다.

## 2️⃣ 알아두시면 좋아요!

### bug 원인
-  @yourssu/crypto의 ```base64Encode``` 함수는 UTF-8 문자열을 input으로 받습니다.
- @yourssu/crypto의 ```sha256```은 HEX 문자열을 반환합니다.
- 따라서 ```sha256```의 반환값을 ```base64Encode```에 그대로 넣으면 문제가 발생합니다.

### 해결 방법
- ```hexToUtf8``` 함수를 중간에 한 번 거치면 문제가 해결됩니다. 사용법은 아래와 같습니다.
```typescript
base64Encode(hexToUtf8(sha256('test')))
```

### 요청사항
- ```en.md``` 파일과 ```ko.md``` 파일이 이상하게 저장돼서 고쳐주시면 감사하겠습니다. ㅎㅎ

## 3️⃣ 추후 작업

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
