### PR TITLE
fix(@yourssu/logging-system): 비회원일 때 해시 값이 달라지는 문제 해결

### DIFF
--- a/packages/logging-system/src/Logger.ts
+++ b/packages/logging-system/src/Logger.ts
@@ -19,21 +19,21 @@ const createRandomId = () => {
 };
 
 const createHashedID = (userId: string) => {
-  let hashedId = '';
-  let localHashedId = '';
-  const existLocalHashedId = window.localStorage.getItem('yls-web');
+  const existLocalHashedId = window.sessionStorage.getItem('yls-web-hashedId');
 
   if (userId === '') {
     if (existLocalHashedId) {
-      localHashedId = JSON.parse(window.localStorage.getItem('yls-web') as string).hashedId;
+      return existLocalHashedId;
     } else {
       userId = createRandomId();
     }
   }
 
-  hashedId = base64Encode(hexToUtf8(sha256(userId)));
+  const hashId = base64Encode(hexToUtf8(sha256(userId)));
 
-  return localHashedId ? localHashedId : hashedId;
+  window.sessionStorage.setItem('yls-web-hashedId', hashId);
+
+  return hashId;
 };
 
 const createTimestamp = () => {

--- a/packages/logging-system/src/Logger.ts
+++ b/packages/logging-system/src/Logger.ts
@@ -18,22 +18,18 @@ const createRandomId = () => {
   return randomId;
 };
 
-const createHashedID = (userId: string) => {
+const createHashedId = (userId: string) => {
   const existLocalHashedId = window.sessionStorage.getItem('yls-web-hashedId');
 
-  if (userId === '') {
-    if (existLocalHashedId) {
-      return existLocalHashedId;
-    } else {
-      userId = createRandomId();
-    }
-  }
+  if (userId === '' && existLocalHashedId) return existLocalHashedId;
 
-  const hashId = base64Encode(hexToUtf8(sha256(userId)));
+  if (userId === '') userId = createRandomId();
 
-  window.sessionStorage.setItem('yls-web-hashedId', hashId);
+  const hashedId = base64Encode(hexToUtf8(sha256(userId)));
 
-  return hashId;
+  window.sessionStorage.setItem('yls-web-hashedId', hashedId);
+
+  return hashedId;
 };
 
 const createTimestamp = () => {
@@ -78,7 +74,7 @@ export const useYLSLogger = () => {
 
 export const Logger = ({ userId, version, event }: LogPayloadParams) => {
   return {
-    hashedID: createHashedID(userId),
+    hashedID: createHashedId(userId),
     timestamp: createTimestamp(),
     version: version,
     event: {


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- resolved #62 

### 기존 코드에 영향을 미치는 변경사항

- 기존 코드는 localStorage의  `yls-web`에서 `hashedId`를 가져오는데, hashedId라는 필드가 존재하지 않습니다.
- 따라서 sessionStorage에 `yls-web-hashed-id`라는 필드를 추가하고, 거기에 hasedId를 별도로 저장하도록 변경했습니다.

### 버그 픽스

<img width="325" alt="image" src="https://github.com/user-attachments/assets/c574c039-c11c-41ca-8433-bc98093d36f6">

- 비회원일 때도 해시 값이 랜덤으로 생성되어서 변경되지 않습니다.

## 2️⃣ 알아두시면 좋아요!

- sessionStorage를 사용한 이유는, 안드로이드 쪽에 여쭤봤을 때 비회원인 경우 앱이 실행되면 랜덤한 userId를 생성하고 앱을 종료할 때 까지 그 userId를 유지 시킨다고 하셨습니다. 따라서 웹의 경우에도 브라우저를 최초 실행할 때 userId를 새로 생성할 수 있도록 sessionStorage를 사용했습니다.
- 기존에는 userId가 빈 문자열일 때를 기준으로 sha-256 hashing이 진행되었습니다. 그래서 아마... 모든 유저의 해시 값이 똑같이 들어갔을 겁니다.

## 3️⃣ 추후 작업

- 10번째 로그의 손실과, 중복 로그, 이탈 시 로그 등 여러 이슈를 해결합니다.

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
