### PR TITLE
feat(@yourssu/logging-system): fix 10th lost-log

### DIFF
--- a/packages/logging-system/src/SetLocalStorage.ts
+++ b/packages/logging-system/src/SetLocalStorage.ts
@@ -1,8 +1,10 @@
 import { LogRequestList, LogResponse, LogType } from './types/LogType';
 
-export const SetLocalStorageClear = () => {
-  const list: any[] = [];
-  localStorage.setItem('yls-web', JSON.stringify(list));
+const logSize = 10;
+
+export const SetLocalStorageSlice = () => {
+  const list: LogType[] = JSON.parse(localStorage.getItem('yls-web') as string) || [];
+  localStorage.setItem('yls-web', JSON.stringify(list.slice(logSize, list.length)));
 };
 
 export const SetLocalStorage = async (
@@ -13,16 +15,21 @@ export const SetLocalStorage = async (
   list.push(logger);
   localStorage.setItem('yls-web', JSON.stringify(list));
 
-  if (list.length >= 10) {
+  const slicingList = list.slice(0, logSize);
+
+  if (list.length >= logSize) {
     const req: LogRequestList = {
-      logRequestList: list,
+      logRequestList: slicingList,
     };
-    SetLocalStorageClear();
+    SetLocalStorageSlice();
 
     try {
       await putLog(req);
     } catch (e) {
       console.error('Failed to post log');
+      const remainList: LogType[] = JSON.parse(localStorage.getItem('yls-web') as string) || [];
+      remainList.unshift(...slicingList);
+      localStorage.setItem('yls-web', JSON.stringify(remainList));
     }
   }
 };

--- a/packages/logging-system/src/SetLocalStorage.ts
+++ b/packages/logging-system/src/SetLocalStorage.ts
@@ -1,10 +1,8 @@
 import { LogRequestList, LogResponse, LogType } from './types/LogType';
 
-const logSize = 10;
-
-export const SetLocalStorageSlice = () => {
-  const list: LogType[] = JSON.parse(localStorage.getItem('yls-web') as string) || [];
-  localStorage.setItem('yls-web', JSON.stringify(list.slice(logSize, list.length)));
+export const SetLocalStorageClear = () => {
+  const list: LogType[] = [];
+  localStorage.setItem('yls-web', JSON.stringify(list));
 };
 
 export const SetLocalStorage = async (
@@ -15,21 +13,18 @@ export const SetLocalStorage = async (
   list.push(logger);
   localStorage.setItem('yls-web', JSON.stringify(list));
 
-  const slicingList = list.slice(0, logSize);
+  const req: LogRequestList = {
+    logRequestList: list,
+  };
 
-  if (list.length >= logSize) {
-    const req: LogRequestList = {
-      logRequestList: slicingList,
-    };
-    SetLocalStorageSlice();
+  SetLocalStorageClear();
 
-    try {
-      await putLog(req);
-    } catch (e) {
-      console.error('Failed to post log');
-      const remainList: LogType[] = JSON.parse(localStorage.getItem('yls-web') as string) || [];
-      remainList.unshift(...slicingList);
-      localStorage.setItem('yls-web', JSON.stringify(remainList));
-    }
+  try {
+    await putLog(req);
+  } catch (e) {
+    console.error('Failed to post log');
+    const remainList: LogType[] = JSON.parse(localStorage.getItem('yls-web') as string) || [];
+    remainList.unshift(...list);
+    localStorage.setItem('yls-web', JSON.stringify(remainList));
   }
 };

--- a/packages/logging-system/src/SetLocalStorage.ts
+++ b/packages/logging-system/src/SetLocalStorage.ts
@@ -13,18 +13,20 @@ export const SetLocalStorage = async (
   list.push(logger);
   localStorage.setItem('yls-web', JSON.stringify(list));
 
-  const req: LogRequestList = {
-    logRequestList: list,
-  };
+  if (list.length >= 10) {
+    const req: LogRequestList = {
+      logRequestList: list,
+    };
 
-  SetLocalStorageClear();
+    SetLocalStorageClear();
 
-  try {
-    await putLog(req);
-  } catch (e) {
-    console.error('Failed to post log');
-    const remainList: LogType[] = JSON.parse(localStorage.getItem('yls-web') as string) || [];
-    remainList.unshift(...list);
-    localStorage.setItem('yls-web', JSON.stringify(remainList));
+    try {
+      await putLog(req);
+    } catch (e) {
+      console.error('Failed to post log');
+      const remainList: LogType[] = JSON.parse(localStorage.getItem('yls-web') as string) || [];
+      remainList.unshift(...list);
+      localStorage.setItem('yls-web', JSON.stringify(remainList));
+    }
   }
 };

--- a/packages/logging-system/src/SetLocalStorage.ts
+++ b/packages/logging-system/src/SetLocalStorage.ts
@@ -9,28 +9,20 @@ export const SetLocalStorage = async (
   logger: LogType,
   putLog: (data: LogRequestList) => Promise<LogResponse>
 ) => {
-  if (window.localStorage.getItem('yls-web') == undefined) {
-    const list: any[] = [];
-    list.push(logger);
-    localStorage.setItem('yls-web', JSON.stringify(list));
-  } else {
-    const remainList: any[] = JSON.parse(localStorage.getItem('yls-web') as string) || [];
-    if (remainList.length < 10) {
-      const updateList = [...remainList, logger];
-      localStorage.setItem('yls-web', JSON.stringify(updateList));
-    } else {
-      const req: LogRequestList = {
-        logRequestList: remainList,
-      };
+  const list: LogType[] = JSON.parse(localStorage.getItem('yls-web') as string) || [];
+  list.push(logger);
+  localStorage.setItem('yls-web', JSON.stringify(list));
 
-      try {
-        const res = await putLog(req);
-        if (res.success) {
-          SetLocalStorageClear();
-        }
-      } catch (e) {
-        console.error('Failed to post log');
-      }
+  if (list.length >= 10) {
+    const req: LogRequestList = {
+      logRequestList: list,
+    };
+    SetLocalStorageClear();
+
+    try {
+      await putLog(req);
+    } catch (e) {
+      console.error('Failed to post log');
     }
   }
 };


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- resolved #53

### 기존 코드에 영향을 미치지 않는 변경사항

- 없습니다.

### 기존 코드에 영향을 미치는 변경사항

- 기존에는 log 전송에 성공하면 localStorage를 비웠으나, 지금은 localStorage를 미리 비우고, 전송에 실패하면 다시 복원합니다. 이렇게 하면 같은 로그에 대한 중복 호출을 방지할 수 있습니다.
- 10번 째 로그가 날아간 이유는 기존에 10번 쨰 로그가 들어오면 해당 로그를 포함하지 않은 `remainList`를 전송하기 때문입니다. 지금은 10번 째 로그가 들어오자마자 이를 포함해 전송합니다.

### 버그 픽스

- 10번 째 로그가 손실되는 문제를 해결했습니다.
- 같은 로그를 반복적으로 전송할 수 있는 문제를 해결했습니다.

## 2️⃣ 알아두시면 좋아요!

- 기존 제안되었던 timestamp 대신 더 간단한 방식을 사용했습니다. 다만 이렇게 하면 로그를 재전송 했을 때 로그 수가 10 <= 이 될 가능성이 있습니다 

## 3️⃣ 추후 작업

- 사용자 이탈 시 로그 전송 작업을 마무리 후 새로운 버전을 배포합니다.

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
